### PR TITLE
CSI-325 Fix OpenTofu output capture failure

### DIFF
--- a/.github/workflows/terraform-reusable.yml
+++ b/.github/workflows/terraform-reusable.yml
@@ -209,6 +209,8 @@ jobs:
         run: |
           terraform apply -auto-approve
         
-          echo "terraform-outputs<<EOF" >> $GITHUB_OUTPUT
+          {
+          echo "terraform-outputs<<EOF"
           terraform output -json 2>/dev/null || echo "{}"
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "EOF"
+          } >> $GITHUB_OUTPUT

--- a/.github/workflows/terraform-reusable.yml
+++ b/.github/workflows/terraform-reusable.yml
@@ -43,7 +43,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     outputs:
-      terraform-outputs: ${{ steps.plan.terraform-outputs }}
+      terraform-outputs: ${{ steps.apply.terraform-outputs }}
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/terraform-reusable.yml
+++ b/.github/workflows/terraform-reusable.yml
@@ -43,7 +43,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     outputs:
-      terraform-outputs: ${{ steps.apply.terraform-outputs }}
+      terraform-outputs: ${{ steps.apply.outputs.terraform-outputs }}
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/terraform-reusable.yml
+++ b/.github/workflows/terraform-reusable.yml
@@ -209,4 +209,6 @@ jobs:
         run: |
           terraform apply -auto-approve
         
-          echo "terraform-outputs=$(terraform output -json)" >> $GITHUB_OUTPUT
+          echo "terraform-outputs<<EOF" >> $GITHUB_OUTPUT
+          terraform output -json 2>/dev/null || echo "{}"
+          echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/tofu-reusable.yml
+++ b/.github/workflows/tofu-reusable.yml
@@ -79,7 +79,10 @@ jobs:
             value=$(echo $line | jq -r .value)
 
             echo "$name=$value" >> $GITHUB_ENV
-            echo "::add-mask::$value"
+            
+            if [ -n "$value" ]; then
+              echo "::add-mask::$value"
+            fi
           done
 
       - name: Tofu Format

--- a/.github/workflows/tofu-reusable.yml
+++ b/.github/workflows/tofu-reusable.yml
@@ -51,7 +51,7 @@ jobs:
       TF_VAR_local_state_passphrase: ${{ secrets.TF_LOCAL_STATE_ENCRYPTION_KEY }}
       TF_VAR_shared_state_passphrase: ${{ secrets.TF_SHARED_RESOURCES_STATE_ENCRYPTION_KEY }}
     outputs:
-      tofu-outputs: ${{ steps.apply.tofu-outputs }}
+      tofu-outputs: ${{ steps.apply.outputs.tofu-outputs }}
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/tofu-reusable.yml
+++ b/.github/workflows/tofu-reusable.yml
@@ -74,16 +74,18 @@ jobs:
       - name: Secrets to ENV
         shell: bash
         run: |
-          for line in $(echo "${{ secrets.TF_SECRETS }}" | jq -c '.[]' ); do
-            name=$(echo $line | jq -r .name)
-            value=$(echo $line | jq -r .value)
-
-            echo "$name=$value" >> $GITHUB_ENV
-            
-            if [ -n "$value" ]; then
-              echo "::add-mask::$value"
-            fi
-          done
+          if [ -n "${{ secrets.TF_SECRETS }}" ]; then
+            for line in $(echo "${{ secrets.TF_SECRETS }}" | jq -c '.[]' ); do
+              name=$(echo $line | jq -r .name)
+              value=$(echo $line | jq -r .value)
+              
+              # Only set the variable if it has a value
+              if [ -n "$value" ]; then
+                echo "$name=$value" >> $GITHUB_ENV
+                echo "::add-mask::$value"
+              fi
+            done
+          fi
 
       - name: Tofu Format
         working-directory: ${{ inputs.iac-path }}

--- a/.github/workflows/tofu-reusable.yml
+++ b/.github/workflows/tofu-reusable.yml
@@ -219,7 +219,6 @@ jobs:
         if: ${{ inputs.run-apply }}
         working-directory: ${{ inputs.iac-path }}
         run: |
-          tofu apply -auto-approve -no-color
 
           echo "=== DEBUG: Attempting to capture outputs ==="
           RAW_OUTPUT=$(tofu output -json 2>&1) || echo "Command failed with exit code: $?"

--- a/.github/workflows/tofu-reusable.yml
+++ b/.github/workflows/tofu-reusable.yml
@@ -51,7 +51,7 @@ jobs:
       TF_VAR_local_state_passphrase: ${{ secrets.TF_LOCAL_STATE_ENCRYPTION_KEY }}
       TF_VAR_shared_state_passphrase: ${{ secrets.TF_SHARED_RESOURCES_STATE_ENCRYPTION_KEY }}
     outputs:
-      tofu-outputs: ${{ steps.plan.tofu-outputs }}
+      tofu-outputs: ${{ steps.apply.tofu-outputs }}
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/tofu-reusable.yml
+++ b/.github/workflows/tofu-reusable.yml
@@ -238,7 +238,12 @@ jobs:
           FIXED_OUTPUT=$(echo "$RAW_OUTPUT" | \
             sed 's/tolist([^)]*)/[]/g' | \
             sed 's/toset([^)]*)/[]/g' | \
-            sed 's/tomap([^)]*)/{}/g')
+            sed 's/tomap([^)]*)/{}/g' | \
+            sed 's/: \*\*\*$/: []/g' | \
+            sed 's/: \*\*\*,/: [],/g' | \
+            sed 's/\*\*\*$/}/g' | \
+            sed 's/\*\*\*,$/},/g' | \
+            sed 's/^\*\*\*$/{/g')
           
           if echo "$FIXED_OUTPUT" | jq . >/dev/null 2>&1; then
             echo "=== DEBUG: JSON is now valid after fixing ==="

--- a/.github/workflows/tofu-reusable.yml
+++ b/.github/workflows/tofu-reusable.yml
@@ -220,9 +220,37 @@ jobs:
         working-directory: ${{ inputs.iac-path }}
         run: |
           tofu apply -auto-approve
+
+          echo "=== DEBUG: Attempting to capture outputs ==="
+          RAW_OUTPUT=$(tofu output -json 2>&1) || echo "Command failed with exit code: $?"
+          
+          echo "=== DEBUG: Raw output length: ${#RAW_OUTPUT} ==="
+          echo "=== DEBUG: First 500 chars of raw output ==="
+          echo "${RAW_OUTPUT:0:500}"
+
+          if echo "$RAW_OUTPUT" | grep -q '\*\*\*'; then
+            echo "=== DEBUG: Output contains masked values (***) ==="
+          else
+            echo "=== DEBUG: No masked values detected ==="
+          fi
           
           {
           echo "tofu-outputs<<EOF"
           tofu output -json 2>/dev/null || echo "{}"
           echo "EOF"
           } >> $GITHUB_OUTPUT
+
+          echo "=== DEBUG: Content written to GITHUB_OUTPUT ==="
+
+      - name: Verify Output Capture
+        if: ${{ inputs.run-apply }}
+        run: |
+          echo "=== VERIFY: Checking what was captured ==="
+          echo "Output value length: ${#OUTPUT}"
+          if [ -z "$OUTPUT" ]; then
+            echo "WARNING: Output is empty!"
+          else
+            echo "Output appears to be captured"
+          fi
+        env:
+          OUTPUT: ${{ steps.apply.outputs.tofu-outputs }}

--- a/.github/workflows/tofu-reusable.yml
+++ b/.github/workflows/tofu-reusable.yml
@@ -74,18 +74,12 @@ jobs:
       - name: Secrets to ENV
         shell: bash
         run: |
-          if [ -n "${{ secrets.TF_SECRETS }}" ]; then
-            for line in $(echo "${{ secrets.TF_SECRETS }}" | jq -c '.[]' ); do
-              name=$(echo $line | jq -r .name)
-              value=$(echo $line | jq -r .value)
-              
-              # Only set the variable if it has a value
-              if [ -n "$value" ]; then
-                echo "$name=$value" >> $GITHUB_ENV
-                echo "::add-mask::$value"
-              fi
-            done
-          fi
+          for line in $(echo "${{ secrets.TF_SECRETS }}" | jq -c '.[]' ); do
+            name=$(echo $line | jq -r .name)
+            value=$(echo $line | jq -r .value)
+            echo "$name=$value" >> $GITHUB_ENV
+            echo "::add-mask::$value"
+          done
 
       - name: Tofu Format
         working-directory: ${{ inputs.iac-path }}
@@ -95,7 +89,7 @@ jobs:
       - name: Tofu Init
         id: init
         working-directory: ${{ inputs.iac-path }}
-        run: tofu init -no-color
+        run: tofu init
 
       - name: Tofu Validate
         id: validate
@@ -224,48 +218,13 @@ jobs:
         if: ${{ inputs.run-apply }}
         working-directory: ${{ inputs.iac-path }}
         run: |
+          tofu apply -auto-approve
 
-          echo "=== DEBUG: Attempting to capture outputs ==="
-          RAW_OUTPUT=$(tofu output -json 2>&1) || echo "Command failed with exit code: $?"
-          
-          echo "=== DEBUG: Raw output length: ${#RAW_OUTPUT} ==="
-          echo "=== DEBUG: First 500 chars of raw output ==="
-          echo "${RAW_OUTPUT:0:500}"
-
-          if echo "$RAW_OUTPUT" | grep -q '\*\*\*'; then
-            echo "=== DEBUG: Output contains masked values (***) ==="
-          else
-            echo "=== DEBUG: No masked values detected ==="
-          fi
-          
-          echo "=== DEBUG: Attempting to fix malformed JSON patterns ==="
-          FIXED_OUTPUT=$(echo "$RAW_OUTPUT" | \
-            sed 's/tolist([^)]*)/[]/g' | \
-            sed 's/toset([^)]*)/[]/g' | \
-            sed 's/tomap([^)]*)/{}/g' | \
-            sed 's/: \*\*\*$/: []/g' | \
-            sed 's/: \*\*\*,/: [],/g' | \
-            sed 's/\*\*\*$/}/g' | \
-            sed 's/\*\*\*,$/},/g' | \
-            sed 's/^\*\*\*$/{/g')
-          
-          if echo "$FIXED_OUTPUT" | jq . >/dev/null 2>&1; then
-            echo "=== DEBUG: JSON is now valid after fixing ==="
-            {
-              echo "tofu-outputs<<EOF"
-              echo "$FIXED_OUTPUT"
-              echo "EOF"
-            } >> $GITHUB_OUTPUT
-          else
-            echo "=== DEBUG: JSON still invalid, using fallback ==="
-            {
+          {
               echo "tofu-outputs<<EOF"
               tofu output -json 2>/dev/null || echo "{}"
               echo "EOF"
-            } >> $GITHUB_OUTPUT
-          fi
-
-          echo "=== DEBUG: Content written to GITHUB_OUTPUT ==="
+          } >> $GITHUB_OUTPUT
 
       - name: Verify Output Capture
         if: ${{ inputs.run-apply }}

--- a/.github/workflows/tofu-reusable.yml
+++ b/.github/workflows/tofu-reusable.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Tofu Init
         id: init
         working-directory: ${{ inputs.iac-path }}
-        run: tofu init
+        run: tofu init -no-color
 
       - name: Tofu Validate
         id: validate
@@ -219,7 +219,7 @@ jobs:
         if: ${{ inputs.run-apply }}
         working-directory: ${{ inputs.iac-path }}
         run: |
-          tofu apply -auto-approve
+          tofu apply -auto-approve -no-color
 
           echo "=== DEBUG: Attempting to capture outputs ==="
           RAW_OUTPUT=$(tofu output -json 2>&1) || echo "Command failed with exit code: $?"

--- a/.github/workflows/tofu-reusable.yml
+++ b/.github/workflows/tofu-reusable.yml
@@ -221,6 +221,8 @@ jobs:
         run: |
           tofu apply -auto-approve
           
-          echo "tofu-outputs<<EOF" >> $GITHUB_OUTPUT
+          {
+          echo "tofu-outputs<<EOF"
           tofu output -json 2>/dev/null || echo "{}"
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "EOF"
+          } >> $GITHUB_OUTPUT

--- a/.github/workflows/tofu-reusable.yml
+++ b/.github/workflows/tofu-reusable.yml
@@ -234,11 +234,27 @@ jobs:
             echo "=== DEBUG: No masked values detected ==="
           fi
           
-          {
-          echo "tofu-outputs<<EOF"
-          tofu output -json 2>/dev/null || echo "{}"
-          echo "EOF"
-          } >> $GITHUB_OUTPUT
+          echo "=== DEBUG: Attempting to fix malformed JSON patterns ==="
+          FIXED_OUTPUT=$(echo "$RAW_OUTPUT" | \
+            sed 's/tolist([^)]*)/[]/g' | \
+            sed 's/toset([^)]*)/[]/g' | \
+            sed 's/tomap([^)]*)/{}/g')
+          
+          if echo "$FIXED_OUTPUT" | jq . >/dev/null 2>&1; then
+            echo "=== DEBUG: JSON is now valid after fixing ==="
+            {
+              echo "tofu-outputs<<EOF"
+              echo "$FIXED_OUTPUT"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
+          else
+            echo "=== DEBUG: JSON still invalid, using fallback ==="
+            {
+              echo "tofu-outputs<<EOF"
+              tofu output -json 2>/dev/null || echo "{}"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
+          fi
 
           echo "=== DEBUG: Content written to GITHUB_OUTPUT ==="
 
@@ -251,6 +267,7 @@ jobs:
             echo "WARNING: Output is empty!"
           else
             echo "Output appears to be captured"
+            echo "First 200 chars: ${OUTPUT:0:200}"
           fi
         env:
           OUTPUT: ${{ steps.apply.outputs.tofu-outputs }}

--- a/.github/workflows/tofu-reusable.yml
+++ b/.github/workflows/tofu-reusable.yml
@@ -225,17 +225,3 @@ jobs:
               tofu output -json 2>/dev/null || echo "{}"
               echo "EOF"
           } >> $GITHUB_OUTPUT
-
-      - name: Verify Output Capture
-        if: ${{ inputs.run-apply }}
-        run: |
-          echo "=== VERIFY: Checking what was captured ==="
-          echo "Output value length: ${#OUTPUT}"
-          if [ -z "$OUTPUT" ]; then
-            echo "WARNING: Output is empty!"
-          else
-            echo "Output appears to be captured"
-            echo "First 200 chars: ${OUTPUT:0:200}"
-          fi
-        env:
-          OUTPUT: ${{ steps.apply.outputs.tofu-outputs }}

--- a/.github/workflows/tofu-reusable.yml
+++ b/.github/workflows/tofu-reusable.yml
@@ -221,4 +221,6 @@ jobs:
         run: |
           tofu apply -auto-approve
           
-          echo "tofu-outputs=$(tofu output -json)" >> $GITHUB_OUTPUT
+          echo "tofu-outputs<<EOF" >> $GITHUB_OUTPUT
+          tofu output -json 2>/dev/null || echo "{}"
+          echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Updates

- Handled multiline JSON output.
- Created [tag v0.12.0-beta.5](https://github.com/NIT-Administrative-Systems/ado-reusable-workflows-terraform/releases/tag/v0.12.0-beta.5) for testing.
- Successfully tested Tofu workflow) in [Identity Mapper ](https://github.com/NIT-Administrative-Systems/ia-idmms/pull/212) branch here and confirmed that it is working as expected.  Will close branch when this work is complete.

## Pipeline Output Capture Issue - Summary

### What Happened
When I [upgraded ia-idmms to OpenTofu](https://github.com/NIT-Administrative-Systems/ia-idmms/pull/194), I discovered that I was unable to have the PR check GitHub Action workflow pass due to it [using ado-reusable-workflows-terraform/terraform-reusable.yml](https://github.com/NIT-Administrative-Systems/ia-idmms/pull/194/files) and the Identity Mapper app using OpenTofu.  There was no tofu-resusable.yml at the time, so I [created one and fixed the bug where the output was not being printed to PRs](https://github.com/NIT-Administrative-Systems/ado-reusable-workflows-terraform/pull/6).  I also updated the terraform-reusable.yml file to fix the issue there. I tested this against Identity Mapper, and things appeared to be working as expected.  

Yesterday, Casey discovered ADO Shared Resources GitHub Actions were failing after updating the new version of the ado-reusable-workflows-terraform. The infrastructure deployments succeeded, but the workflows failed when capturing Terraform/OpenTofu outputs.  This GitHub Action uses the Tofu apply component of the reusable action, where the Identity mapper GitHub Action did not, so this was not caught earlier.

### Why I Made the Original Change
GitHub deprecated ::set-output in October 2022 and required migration to $GITHUB_OUTPUT:

Official Deprecation Notice: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
Security Advisory: The old syntax was vulnerable to log injection attacks
Timeline: GitHub announced the old commands would be disabled completely

### The Problem I Found
The new $GITHUB_OUTPUT format requires proper handling of multiline values. When I migrated from:

`echo "::set-output name=outputs::$(terraform output -json)"`
To:
`echo "outputs=$(terraform output -json)" >> $GITHUB_OUTPUT`

I didn't realize that the new format did not handle multiline like the old format. According to GitHub's documentation on multiline outputs:

GitHub Docs - Setting Output Parameters: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
Single-line format: `echo "name=value" >> $GITHUB_OUTPUT`
Multiline format requires heredoc: `echo "name<<EOF" >> $GITHUB_OUTPUT`

### The Red Herring
I initially suspected GitHub's secret masking was creating invalid JSON with *** values. Testing proved this wrong.  The real issue was multiline handling, not masked values.  Note that this was actually an issue for the ADO Shared Resources, but was unrelated to the failure (See notes in [this PR](https://github.com/NIT-Administrative-Systems/ADO-shared-resources-iac/pull/78).)

### Impact

Deployment Status: Infrastructure deployed successfully with only output capture failed
Workflow Status: Pipelines appeared failed despite successful deployments
App at Risk: ADO Shared Resources

### The Fix
I implemented GitHub's documented heredoc syntax for multiline values:
`{
  echo "outputs<<EOF"
  terraform output -json 2>/dev/null || echo "{}"
  echo "EOF"
} >> $GITHUB_OUTPUT`

This follows GitHub's official guidance for multiline strings: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string

### TLDR
The deprecated :: output handled multiline JSON output and the new $GITHUB_OUTPUT format does not.  The fix follows GitHub's documented best practice for multiline outputs with added error handling.