### PR TITLE
CSI-426 February 2026 Dependabot Updates

### DIFF
--- a/.github/workflows/tofu-reusable.yml
+++ b/.github/workflows/tofu-reusable.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6.0.2
 
       - name: Cache Comment Id
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
### Update
- actions/checkout from v6.0.1 to v6.0.2

Note: I am intentionally not updating the Terraform dependencies, as we are no longer using Terraform.  Open to updating it in the future