### PR TITLE
CSI-521 May Dependabot Updates

### DIFF
--- a/.github/workflows/tofu-reusable.yml
+++ b/.github/workflows/tofu-reusable.yml
@@ -60,13 +60,13 @@ jobs:
       - name: Cache Comment Id
         if: github.event_name == 'pull_request'
         id: cache-comment-id
-        uses: actions/cache@v5.0.3
+        uses: actions/cache@v5.0.5
         with:
           path: ./comment-cache
           key: pr-${{ github.event.number }}-comment-id${{ inputs.cache-key-suffix }}
 
       - name: Setup OpenTofu
-        uses: opentofu/setup-opentofu@v1.0.8
+        uses: opentofu/setup-opentofu@v2.0.0
         with:
           tofu_version: ${{ inputs.tofu-version }}
           tofu_wrapper: false
@@ -116,7 +116,7 @@ jobs:
       - name: Update PR Comment with Plan
         if: steps.cache-comment-id.outputs.cache-hit == 'true' && github.event_name == 'pull_request'
         id: update-pr-comment
-        uses: actions/github-script@v8.0.0
+        uses: actions/github-script@v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           result-encoding: string


### PR DESCRIPTION
## What Changed
Routine dependency updates for `tofu-reusable.yml`. Terraform workflow left untouched and still maintained for backward compatibility with any remaining consumers.

## Version changes
| Action | From | To | Notes |
|---|---|---|---|
| actions/cache | v5.0.3 | v5.0.5 | Patch — resolves upstream dependabot alert in `@actions/cache` |
| opentofu/setup-opentofu | v1.0.8 | v2.0.0 | Major — inputs unchanged for our usage |
| actions/github-script | v8.0.0 | v9.0.0 | Major — `github.rest.*` API and our scripts unaffected |

## Breaking-change review (None here)
**setup-opentofu v2:** `tofu_version` and `tofu_wrapper` inputs unchanged. 
New optional inputs (`checksums`, `cache`, `provider_acceptance_tests`) 
not used here.

**github-script v9:** Breaking changes are `require('@actions/github')` 
removal and `getOctokit` becoming an injected parameter. Neither pattern 
is used in our scripts. We only call `github.rest.issues.{create,update}Comment` 
and `require('fs')`.